### PR TITLE
Ignore versions when converting ClrType string to a type

### DIFF
--- a/src/eventstore/EventStoreAggregateEventDispatcher.cs
+++ b/src/eventstore/EventStoreAggregateEventDispatcher.cs
@@ -60,7 +60,15 @@ namespace CR.MessageDispatch.EventStore
                 {
                     try
                     {
-                        cached = Type.GetType((string)metadata["ClrType"], true);
+                        cached = Type.GetType(
+                            (string)metadata["ClrType"],
+                            (assemblyName) => {
+                                assemblyName.Version = null;
+                                return System.Reflection.Assembly.Load(assemblyName);
+                            },
+                            null,
+                            true,
+                            true);
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
Uses a custom assembly resolver when loading the `Type` for a `ClrType` field in an aggregate event. This prevents issues when used in a strongly named context.